### PR TITLE
refactor: common styling in globals.css and old repo changes to layout.tsx

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,10 +1,110 @@
 @import 'tailwindcss';
 
-html,
-body {
-  height: 100%; /* Ensure html and body take full viewport height */
-  margin: 0;
-  padding: 0;
-  font-family: sans-serif; /* Example font */
-  box-sizing: border-box;
+@theme inline {
+  /* some colors from Figma prototypes */
+  --color-brand-dark-grey: #383838;
+  --color-brand-dark-purple: #411A63;
+  --color-brand-indigo: #470085;
+  --color-brand-pale-purple: #DEB8FE;
+  --color-brand-cobalt-blue: #2F419B;
+  --color-brand-pale-blue: #E2E8FD;
+  --color-brand-dark-pastel-purple: #9580D7;
+  --color-brand-light-steel-blue: #7289DA;
+  --color-brand-lilac: #CDA8F9;
+
+  /* some Mozilla colors */
+  --color-brand-ironside-grey: #666666;
+  --color-brand-dark-dune-grey: #333333;
+
+  /* primary RCC brand colors */
+  --color-brand-dark-lavender: #7972a8;
+  --color-brand-lavender: #c4baea;
+  --color-brand-dull-periwinkle: #93a2e2;
+  --color-brand-baby-pink: #f6badf;
+  --color-brand-baby-blue: #9bd6f5;
+
+  /* supporting RCC brand colors */
+  --color-brand-dark-violet: #280b63;
+  --color-brand-pale-violet: #caaaf3;
+  --color-brand-dark-periwinkle: #576dd2;
+}
+
+:root {
+  /* some colors from Figma prototypes */
+  --color-brand-dark-grey: #383838;
+  --color-brand-dark-purple: #411A63;
+  --color-brand-indigo: #470085;
+  --color-brand-pale-purple: #DEB8FE;
+  --color-brand-cobalt-blue: #2F419B;
+  --color-brand-pale-blue: #E2E8FD;
+  --color-brand-dark-pastel-purple: #9580D7;
+  --color-brand-light-steel-blue: #7289DA;
+  --color-brand-lilac: #CDA8F9;
+
+  /* some Mozilla colors */
+  --color-brand-ironside-grey: #666666;
+  --color-brand-dark-dune-grey: #333333;
+
+  /* primary RCC brand colors */
+  --color-brand-dark-lavender: #7972a8;
+  --color-brand-lavender: #c4baea;
+  --color-brand-dull-periwinkle: #93a2e2;
+  --color-brand-baby-pink: #f6badf;
+  --color-brand-baby-blue: #9bd6f5;
+
+  /* supporting RCC brand colors */
+  --color-brand-dark-violet: #280b63;
+  --color-brand-pale-violet: #caaaf3;
+  --color-brand-dark-periwinkle: #576dd2;
+}
+
+@layer base {
+  body {
+    color: var(--color-brand-dark-grey);
+    font-family: var(--font-nunito-sans);
+  }
+
+  h1, h2, h3, h4, h5, h6 {
+    font-family: var(--font-zilla-slab);
+  }
+
+  h1 {
+    color: var(--color-brand-indigo);
+    font-size: 50pt;
+  }
+
+  p {
+    max-width: 70ch;
+    line-height: 1.5;
+    font-size: 19;
+    margin-bottom: 2.25em;
+  }
+
+  a {
+    color: var(--color-brand-indigo);
+  }
+
+  hr {
+    outline: black;
+    width: 100%;
+  }
+}
+
+/* class for future accessibility feature (a skip link) */
+.skip-to-content-link {
+  @apply bg-[var(--color-brand-dark-violet)] p-2 lg:p-3 top-2 left-2 absolute;
+  /* background: var(--color-brand-blue-peacock);
+  padding: 10px;
+  top: 1%;
+  left: 1%;
+  position: absolute;
+  transform: translateY(-100%); */
+  transition: transform 0.3s;
+  color: white;
+  outline-color: var(--color-brand-dark-periwinkle);
+  outline-offset: 3px;
+}
+
+.skip-to-content-link:focus {
+  transform: translateY(0%);
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,23 +1,30 @@
 import type { Metadata } from 'next';
-import { Geist, Geist_Mono } from 'next/font/google';
+import { Inter, Nunito_Sans, Zilla_Slab } from 'next/font/google';
 import './globals.css';
 import Header from '@/components/header/Header';
 import styles from './page.module.css';
 
-// UPDATE FOR RCC SITE
-const geistSans = Geist({
-  variable: '--font-geist-sans',
+const inter = Inter({
   subsets: ['latin'],
+  variable: '--font-inter',
+  weight: '400',
 });
 
-const geistMono = Geist_Mono({
-  variable: '--font-geist-mono',
+const nunitoSans = Nunito_Sans({
   subsets: ['latin'],
+  variable: '--font-nunito-sans',
+  weight: '500',
+});
+
+const zillaSlab = Zilla_Slab({
+  subsets: ['latin'],
+  variable: '--font-zilla-slab',
+  weight: '500',
 });
 
 export const metadata: Metadata = {
   title: 'RCC Site',
-  description: '',
+  description: "Member Portal for SJSU's Responsible Computing Club",
 };
 
 export default function RootLayout({
@@ -27,7 +34,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={`${geistSans.variable} ${geistMono.variable} antialiased ${styles.container}`}>
+      <body className={`${nunitoSans.variable} ${inter.variable} ${zillaSlab.variable}`}>
         {/* The Header component will appear on all pages */}
         <Header />
         {/* All your page content will be rendered inside this main tag */}


### PR DESCRIPTION
- added old repo changes to layout.tsx, such as font addition

Migrated the following changes to global.css from the old repo:
- added some common colors from the Figma prototypes, as well as some RCC brand colors
- basic styling of common elements, like body, p, and hr tags
- added a class for styling a skip link (an accessibility feature)