### PR TITLE
fix: protected routes must now be defined in middleware.ts to benefit from auth checking

### DIFF
--- a/src/app/(protected)/privateCheck/page.tsx
+++ b/src/app/(protected)/privateCheck/page.tsx
@@ -1,8 +1,3 @@
-import { getUser } from '@/app/utils/authUtils/authHelpers';
-
-export default async function PrivatePage() {
-  // const user = await checkAuthStatus();
-  const user = await getUser();
-
-  return <p>Hello {user?.email}</p>;
+export default function PrivatePage() {
+  return <p>PROTECTED ROUTE CHECK</p>;
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,5 +1,5 @@
 import { type NextRequest, NextResponse } from 'next/server';
-import { createClient } from '../../utils/supabase/server';
+import { createClient } from '../utils/supabase/server';
 
 // On every request (going to a new page), this middleware activates
 export async function middleware(request: NextRequest) {
@@ -11,11 +11,8 @@ export async function middleware(request: NextRequest) {
     data: { user },
   } = await supabase.auth.getUser();
 
-  // Define the protected route path.
-  const protectedPath = '/protected';
-
   // Check if the user is not authenticated and the requested path is a protected one.
-  if (!user && request.nextUrl.pathname.startsWith(protectedPath)) {
+  if (!user) {
     // Redirect to the login page or an auth-error page.
     return NextResponse.redirect(new URL('/auth-error', request.url));
   }
@@ -24,6 +21,8 @@ export async function middleware(request: NextRequest) {
   return NextResponse.next();
 }
 
+// ADD ALL PROTECTED ROUTES HERE
+// CONFIG WILL AUTOMATICALLY APPLY THE MIDDLEWARE TO THE ROUTES INSIDE THE MATCHER
 export const config = {
-  matcher: ['/protected/:path*'],
+  matcher: ['/privateCheck/:path*'],
 };


### PR DESCRIPTION
Before, the protected route "/privateCheck" had auth checking but only through the helper function "getUser()". Now, the middleware.ts file properly works.

To make a route protected, you must put it into the config inside middleware.ts.. Then, whenever a user goes to that route, the middleware will intervene if they are not logged in, sending them to "/auth-error".