### PR TITLE
fix: navbar closing, mobile navbar dropshadow, background blur on desktop

### DIFF
--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -1,9 +1,10 @@
 "use client"
 
-import React, { useState } from 'react';
+import React, { useRef, useState, useEffect } from 'react';
 import Link from 'next/link';
 import mobileStyles from './mobileHeader.module.css'
 import desktopStyles from "./desktopHeader.module.css"
+
 
 export default function Header() {
 
@@ -16,10 +17,33 @@ export default function Header() {
     const [isDesktopHovered, setIsDesktopHovered] = useState(false)
     const [isDesktopAmbassadorshipClicked, setIsDesktopAmbassadorshipClicked] = useState(false)
 
+    
+  const clickRef = useRef<HTMLElement>(null)
+
+  useEffect(() => {
+  
+    const handleOutsideClick = (event: MouseEvent) => {
+      if (clickRef.current && !clickRef.current.contains(event.target as Node)) {
+        setIsHamburgerClicked(false)
+        setIsMobileHovered(false)
+        setIsMobileAmbassClicked(false)
+        setIsDesktopHovered(false)
+        setIsDesktopAmbassadorshipClicked(false)
+      }
+    }
+
+    document.addEventListener("mousedown", handleOutsideClick)
+
+    return () => {
+      document.removeEventListener("mousedown", handleOutsideClick)
+    }
+
+  })
+
     return (
-      <>        
-        <header className={desktopStyles.header}>
-          
+      <>      
+        <header ref={clickRef} className={desktopStyles.header}>
+
           {/* Mobile Menu */}
           <div className={mobileStyles.mobileContainer}>
 

--- a/src/components/header/desktopHeader.module.css
+++ b/src/components/header/desktopHeader.module.css
@@ -1,6 +1,8 @@
 .header {
   font-family: var(--font-nunito-sans);
   z-index: 10;
+  width: 100vw;
+  position: fixed;
   background-color: white;
 }
 
@@ -35,7 +37,6 @@
   display: flex;
   align-items: center;
   gap: 0.25rem;
-  height: 100%;
 
   :hover {
     cursor: pointer;
@@ -105,16 +106,17 @@
 /* Background blur when Ambassadorship tab is open */
 .backgroundBlur {
   visibility: collapse;
-  height: 100vh;
+  min-height: 100vh;
+  top: 0;
   width: 100vw;
-  position: absolute;
-  background-color: rgba(118, 118, 118, 0.32);
+  position: fixed;
+  background-color: rgba(118, 118, 118, 0.322);
   backdrop-filter: blur(3px);
   z-index: 4;
 }
 
 @media (width >= 40rem) {
-  
+
   .backgroundBlur {
     visibility: visible;
   }

--- a/src/components/header/desktopHeader.module.css
+++ b/src/components/header/desktopHeader.module.css
@@ -6,7 +6,6 @@
 
 .desktopContainer {
   display: none;
-  /* font-size: 1.5rem */
 }
 
 .desktopMainMenu {
@@ -17,8 +16,10 @@
   background-color: white;
   gap: 3.75rem;
   height: 4.25rem;
+  z-index: 15;
 
   > a {
+    font-size: 1.25rem;
     color: var(--color-brand-dark-grey);
   }
 
@@ -43,6 +44,7 @@
   /* ambassadorship text */
   p {
     margin: 0; 
+    font-size: 1.25rem;
     color: var(--color-brand-dark-grey);
   }
 
@@ -73,8 +75,9 @@
   /* submenu links */
   a {
     display: flex;
+    font-size: 1.15rem;
     align-items: center;
-    width: 12.5rem;
+    width: 11.5rem;
     margin: -0.5rem auto 0 auto;
     color: var(--color-brand-dark-grey);
 

--- a/src/components/header/mobileHeader.module.css
+++ b/src/components/header/mobileHeader.module.css
@@ -50,10 +50,10 @@
   display: flex;
   z-index: 10;
   flex-direction: column;
-  font-size: medium;
 
   /* Main Menu Links */
   > a, div {
+    font-size: medium;
     height: 1.75rem;
     display: flex;
     align-items: center;
@@ -79,6 +79,7 @@
 
   p {
     margin: 0;
+    font-size: medium;
   }
 
   div {
@@ -93,14 +94,14 @@
 .mobileSubMenu {
   display: flex;
   z-index: 5;
-  font-size: medium;
   flex-direction: column;
 
   > a {
+    font-size: medium;
     display: flex;
     color: var(--color-brand-dark-grey);
     align-items: center;
-    height: 1.6rem;
+    height: 1.65rem;
     padding: 0 0.75rem 0 0.75rem; 
   }
 }

--- a/src/components/header/mobileHeader.module.css
+++ b/src/components/header/mobileHeader.module.css
@@ -2,6 +2,7 @@
   margin-top: 1rem;
   margin-left: 0.75rem;
   position: absolute;
+  z-index: 15;
 
   /* Main and Sub Menus */
   > div {
@@ -42,6 +43,7 @@
   justify-content: center;
   height: 6rem;
   margin: auto;
+  z-index: 15;
 }
 
 .mobileMainMenu {


### PR DESCRIPTION
- add useEffect() function to detect when user clicks outside of navbar element, and closes navbar menus if so
- increase mobile navbar z-index
- set backgroundBlur's position to "fixed" to make it "follow" user as they scroll, thereby filling the entire viewport

misc.
- make desktop navbar fixed
- change font size for mobile and desktop