### PR TITLE
Fix missing height/width attributes after refactoring Header to use Next.js's Image component in af7b5a14

### DIFF
--- a/src/app/(public)/events/page.tsx
+++ b/src/app/(public)/events/page.tsx
@@ -17,7 +17,7 @@ export default function Events() {
           align="center"
           logoPath="/icons/shape-icon.svg"
           logoAlign="right"
-          logoSize={12}
+          logoSize={84}
           aria-labelledby="events-heading"
         >
           Events

--- a/src/components/Heading/index.tsx
+++ b/src/components/Heading/index.tsx
@@ -21,28 +21,14 @@ export default function Heading({
     >
       {/* Left-aligned logo */}
       {logoPath && logoAlign == 'left' && logoSize && (
-        <Image
-          src={logoPath}
-          className={styles.logo}
-          style={{
-            height: logoSize + 'rem',
-          }}
-          alt=""
-        />
+        <Image src={logoPath} className={styles.logo} height={logoSize} width={logoSize} alt="" />
       )}
 
       <div className={styles.heading}>{children}</div>
 
       {/* Right-aligned logo */}
       {logoPath && logoAlign == 'right' && logoSize && (
-        <Image
-          src={logoPath}
-          className={styles.logo}
-          alt=""
-          style={{
-            width: logoSize + 'rem',
-          }}
-        />
+        <Image src={logoPath} className={styles.logo} alt="" height={logoSize} width={logoSize} />
       )}
     </HeadingTag>
   );


### PR DESCRIPTION
After #af7b5a14, we were still using the style tag to set height/width of the
logo image in the @src/components/Heading component, which now uses Next.js's
native Image component.. This was causing the Events page to not render due to
the missing property.

Fixes this issue by explicitly setting the height/width on the Image's props.
Also increase the size of the logo image to 84 to actually be viewable.
