### PR TITLE
Fix broken /about NavItem in mobile navigation

### DIFF
--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -79,7 +79,7 @@ export default function Header() {
               Home
             </Link>
             <Link
-              href="/#about"
+              href="/about"
               onClick={() => setMobileOpen(false)}
               className="block px-4 py-2 text-sm hover:bg-gray-50 transition-colors"
             >


### PR DESCRIPTION
Found that on the mobile navigation, the About item actually directs to /#about,
a relic of our prior design. This should be a separate page, so the link should
be /about like the desktop navigation.
